### PR TITLE
Fix iframe sample

### DIFF
--- a/samples/basic-component/package.json
+++ b/samples/basic-component/package.json
@@ -11,7 +11,7 @@
         "@vertigis/web": "^5.7.0"
     },
     "devDependencies": {
-        "@vertigis/web-sdk": "^1.1.1",
+        "@vertigis/web-sdk": "^1.2.0",
         "typescript": "~3.9.5"
     },
     "cldr-data-urls-filter": "(cldr-core|cldr-numbers-modern)"

--- a/samples/basic-service/package.json
+++ b/samples/basic-service/package.json
@@ -11,7 +11,7 @@
         "@vertigis/web": "^5.7.0"
     },
     "devDependencies": {
-        "@vertigis/web-sdk": "^1.1.1",
+        "@vertigis/web-sdk": "^1.2.0",
         "typescript": "~3.9.5"
     },
     "cldr-data-urls-filter": "(cldr-core|cldr-numbers-modern)"

--- a/samples/commands-and-operations/package.json
+++ b/samples/commands-and-operations/package.json
@@ -11,7 +11,7 @@
         "@vertigis/web": "^5.7.0"
     },
     "devDependencies": {
-        "@vertigis/web-sdk": "^1.1.1",
+        "@vertigis/web-sdk": "^1.2.0",
         "typescript": "~3.9.5"
     },
     "cldr-data-urls-filter": "(cldr-core|cldr-numbers-modern)"

--- a/samples/i18n/package.json
+++ b/samples/i18n/package.json
@@ -11,7 +11,7 @@
         "@vertigis/web": "^5.7.0"
     },
     "devDependencies": {
-        "@vertigis/web-sdk": "^1.1.1",
+        "@vertigis/web-sdk": "^1.2.0",
         "typescript": "~3.9.5"
     },
     "cldr-data-urls-filter": "(cldr-core|cldr-numbers-modern)"

--- a/samples/iframe/app/parent.html
+++ b/samples/iframe/app/parent.html
@@ -185,17 +185,26 @@
 
                         // Not running locally
                         !event.origin.startsWith("http://localhost:") &&
-                        // Not running in prod
+                        // Not running in production sample viewer
                         !event.origin.endsWith(
                             "vertigis-web-samples.netlify.app"
                         ) &&
-                        // Not running on codesandbox
+                        // Not running on Codesandbox
                         !event.origin.endsWith("codesandbox.io")
                     ) {
                         return;
                     }
 
+                    // If there's no data payload then we can ignore this
+                    // message.
                     if (!event.data) {
+                        return;
+                    }
+
+                    // Codesandbox sends postMessage events that are picked up
+                    // by this event handler. We're only interested in the
+                    // string event data from Geocortex Web.
+                    if (typeof event.data !== "string") {
                         return;
                     }
 

--- a/samples/iframe/package.json
+++ b/samples/iframe/package.json
@@ -4,14 +4,15 @@
     "private": true,
     "scripts": {
         "build": "vertigis-web-sdk build",
-        "start": "vertigis-web-sdk start",
+        "start": "cross-env OPEN_PAGE=/parent.html vertigis-web-sdk start",
         "start-in-sandbox": "SOCK_PORT=443 vertigis-web-sdk start"
     },
     "dependencies": {
         "@vertigis/web": "^5.7.0"
     },
     "devDependencies": {
-        "@vertigis/web-sdk": "^1.1.1",
+        "@vertigis/web-sdk": "^1.2.0",
+        "cross-env": "^7.0.2",
         "typescript": "~3.9.5"
     },
     "cldr-data-urls-filter": "(cldr-core|cldr-numbers-modern)"

--- a/samples/ui-library/package.json
+++ b/samples/ui-library/package.json
@@ -11,7 +11,7 @@
         "@vertigis/web": "^5.7.0"
     },
     "devDependencies": {
-        "@vertigis/web-sdk": "^1.1.1",
+        "@vertigis/web-sdk": "^1.2.0",
         "typescript": "~3.9.5"
     },
     "cldr-data-urls-filter": "(cldr-core|cldr-numbers-modern)"

--- a/yarn.lock
+++ b/yarn.lock
@@ -426,10 +426,10 @@
   resolved "https://registry.yarnpkg.com/@vertigis/viewer-spec/-/viewer-spec-26.3.1.tgz#13a39b7c01e90c94a103168d5d6e926a7718a8dc"
   integrity sha512-+nHf12ZKipc3Ah5XMzcXnQdaoof2CWuIdCiMotpG1zbITLaJS4qXJFgMR4fLj/4eS5vymGK/4yv/u75h60wENA==
 
-"@vertigis/web-sdk@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@vertigis/web-sdk/-/web-sdk-1.1.1.tgz#661d998f8537da0eba0caedcb361c45ae15d1196"
-  integrity sha512-fF4VXe8X8wkKD2JIgVIa4G0kEijxSmlCs1z4XBmdl9dt4KFxQHeWG8U0cqI3++ZGCqOGHC7OCNy0CJvzVKp2RQ==
+"@vertigis/web-sdk@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vertigis/web-sdk/-/web-sdk-1.2.0.tgz#f3fffeb014e3b620ad620fd10664d64bc1eae3d9"
+  integrity sha512-tE7zRdy/zZ2kq576YFDFlZETMExSfoB3GfBFdy4hhgFuj0e3wQSQeBP15MC/roWFcZEbh29qffjpZXXOO1b6oA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^3.3.0"
     "@typescript-eslint/parser" "^3.3.0"


### PR DESCRIPTION
This fixes the iframe sample when running in isolation (from `samples/iframe`), as the page opened was going to the root instead of `parent.html`.