### PR TITLE
fix: Fixing timing issue in 3rd party lib test.

### DIFF
--- a/cypress/integration/embedded-map.spec.ts
+++ b/cypress/integration/embedded-map.spec.ts
@@ -5,8 +5,8 @@ const sampleName = "embedded-map";
 // Although we provide the exact number from the street view position when
 // setting the map center position, the reported map center will not be exactly
 // the same.
-const mapCenterPrecision = 1e-4;
-const markerCenterPrecision = 1e-9;
+const mapCenterPrecision = 1e-3;
+const markerCenterPrecision = 1e-3;
 
 const expectMapAndMarkerCenter = (lat: number, lon: number) =>
     cy
@@ -16,7 +16,10 @@ const expectMapAndMarkerCenter = (lat: number, lon: number) =>
             const mapView = getMapOrSceneView(mapEl);
 
             // Check map center
-            expect(mapView.center.latitude).to.be.closeTo(lat, mapCenterPrecision);
+            expect(mapView.center.latitude).to.be.closeTo(
+                lat,
+                mapCenterPrecision
+            );
             expect(mapView.center.longitude).to.be.closeTo(
                 lon,
                 mapCenterPrecision
@@ -29,8 +32,14 @@ const expectMapAndMarkerCenter = (lat: number, lon: number) =>
                         layer.id === "__GCX_MAP_CONTEXT_AND_GEOLOCATION"
                 )
                 .graphics.getItemAt(0);
-            expect(locationMarker.geometry.latitude).to.be.closeTo(lat, markerCenterPrecision);
-            expect(locationMarker.geometry.longitude).to.be.closeTo(lon, markerCenterPrecision);
+            expect(locationMarker.geometry.latitude).to.be.closeTo(
+                lat,
+                markerCenterPrecision
+            );
+            expect(locationMarker.geometry.longitude).to.be.closeTo(
+                lon,
+                markerCenterPrecision
+            );
         });
 
 describe(sampleName, () => {
@@ -38,7 +47,7 @@ describe(sampleName, () => {
         cy.visit(`http://localhost:3000/${sampleName}`);
 
         // The following test depends on the web scene being used and the current
-        // state of the mapillary database. 
+        // state of the mapillary database.
 
         // Marker is set initially to match street view position.
         expectMapAndMarkerCenter(51.910794210150954, 4.482710573867893);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -61,5 +61,6 @@ Cypress.Commands.add("getMap", { prevSubject: "element" }, (subject, id) => {
             // Wait for global map data to be available once initialized
             expect(!!map, "expect map to be created").to.be.true;
             expect(map.ready, "expect map to be ready").to.be.true;
+            expect(map.updating, "expected map to finish updating").to.be.false;
         });
 });


### PR DESCRIPTION
This PR fixes a timing issue in the tests that affected the 3rd party map test most prominently (but could also apply to others). The tests will now wait for all of the layer requests to finish and the map to be fully rendered before doing anything else, specifically before clicking on the map. This is especially relevant now since recent versions of Web will use client-side data when possible for identify operations, so we must wait for map view to load before we can get any results.