### PR TITLE
Removing default imports of react

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
     "cSpell.words": [
         "Chainable",
+        "Geocortex",
+        "Mapillary",
         "Rerender",
         "arcgis",
         "codesandbox",

--- a/cypress/integration/embedded-map.spec.ts
+++ b/cypress/integration/embedded-map.spec.ts
@@ -63,7 +63,7 @@ describe(sampleName, () => {
 
         // Find the forward arrow by querying for the mapillary node id that
         // represents the next node in the forward direction.
-        cy.getViewer().find('[data-key="6YM7-YAF5IMObwarROA2ZA"]').click();
+        cy.getViewer().find('[data-key="jLUVld0s4wOj4CG8Dv9Jng"]').click();
 
         // Marker is updated to match new street view position.
         // expectMapAndMarkerCenter(51.910737342093, 4.482764649480002);

--- a/cypress/integration/embedded-map.spec.ts
+++ b/cypress/integration/embedded-map.spec.ts
@@ -62,7 +62,9 @@ describe(sampleName, () => {
         // expectMapAndMarkerCenter(51.910794210150954, 4.482710573867893);
 
         // Find the forward arrow by querying for the mapillary node id that
-        // represents the next node in the forward direction.
+        // represents the next node in the forward direction. Note that it's
+        // possible that this value might change over time and might need to be
+        // updated.
         cy.getViewer().find('[data-key="jLUVld0s4wOj4CG8Dv9Jng"]').click();
 
         // Marker is updated to match new street view position.

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es2018",
+        "target": "es2019",
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,
@@ -13,7 +13,7 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": true,
-        "jsx": "react",
+        "jsx": "react-jsx",
         "types": ["cypress"]
     },
     "include": ["**/*"]

--- a/samples/arcgis-widget/src/components/Daylight/Daylight.tsx
+++ b/samples/arcgis-widget/src/components/Daylight/Daylight.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import { ReactElement, useCallback, useState } from "react";
 import { generateUuid } from "@vertigis/arcgis-extensions/utilities/uuid";
 import {
     LayoutElement,
@@ -18,7 +18,7 @@ const DaylightWrapper = createEsriMapWidget(EsriDaylight);
 
 const Daylight = (
     props: LayoutElementProperties<DaylightModel>
-): React.ReactElement => {
+): ReactElement => {
     const [widget, setWidget] = useState<EsriDaylight | null>();
     // A unique DOM ID to be used for a11y purposes.
     const [selectId] = useState(generateUuid());

--- a/samples/arcgis-widget/src/components/Daylight/EsriMapWidget.tsx
+++ b/samples/arcgis-widget/src/components/Daylight/EsriMapWidget.tsx
@@ -2,7 +2,7 @@ import { version } from "esri/kernel";
 import MapView from "esri/views/MapView";
 import SceneView from "esri/views/SceneView";
 import { ComponentModelBase } from "@vertigis/web/models";
-import React, { useEffect, useRef } from "react";
+import { ComponentType, useEffect, useRef } from "react";
 import { useWatchAndRerender } from "@vertigis/web/ui";
 
 function injectCssIfNeeded(): Promise<void> {
@@ -27,9 +27,7 @@ function injectCssIfNeeded(): Promise<void> {
 export function createEsriMapWidget<
     M extends ModelWithMap,
     W extends MapWidget
->(
-    widgetType: MapWidgetConstructor<W>
-): React.ComponentType<MapWidgetProps<M, W>> {
+>(widgetType: MapWidgetConstructor<W>): ComponentType<MapWidgetProps<M, W>> {
     return function EsriWidget(props: MapWidgetProps<M, W>) {
         const { model, onWidgetCreated, onWidgetDestroyed } = props;
         const rootRef = useRef<HTMLDivElement>();

--- a/samples/basic-component/src/components/BasicComponent/BasicComponent.tsx
+++ b/samples/basic-component/src/components/BasicComponent/BasicComponent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactElement } from "react";
 import {
     LayoutElement,
     LayoutElementProperties,
@@ -11,7 +11,7 @@ import "./BasicComponent.css";
 
 const BasicComponent = (
     props: LayoutElementProperties<BasicComponentModel>
-): React.ReactElement => {
+): ReactElement => {
     const { model } = props;
 
     // Watch for changes to the hidden property on the model

--- a/samples/embedded-map/src/components/EmbeddedMap/EmbeddedMap.tsx
+++ b/samples/embedded-map/src/components/EmbeddedMap/EmbeddedMap.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { ReactElement, useEffect, useRef } from "react";
 import { Viewer, TransitionMode } from "mapillary-js";
 import {
     LayoutElement,
@@ -15,7 +15,7 @@ declare const ResizeObserver;
 
 export default function EmbeddedMap(
     props: LayoutElementProperties<EmbeddedMapModel>
-): React.ReactElement {
+): ReactElement {
     const { model } = props;
     const mlyRootEl = useRef<HTMLDivElement>();
 

--- a/samples/i18n/src/components/TranslatableText/TranslatableText.tsx
+++ b/samples/i18n/src/components/TranslatableText/TranslatableText.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { ReactElement, useContext } from "react";
 import {
     LayoutElement,
     LayoutElementProperties,
@@ -10,7 +10,7 @@ import TranslatableTextModel from "./TranslatableTextModel";
 
 export default function TranslatableText(
     props: LayoutElementProperties<TranslatableTextModel>
-): React.ReactElement {
+): ReactElement {
     // The type of the `UIContext` functions will be fixed in 5.8 to be arrow functions.
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const { translate } = useContext(UIContext);

--- a/samples/third-party-lib/src/components/ThreeDimensionalGraph/ThreeDimensionalGraph.tsx
+++ b/samples/third-party-lib/src/components/ThreeDimensionalGraph/ThreeDimensionalGraph.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import { ComponentProps, ReactElement, useRef } from "react";
 import {
     LayoutElement,
     LayoutElementProperties,
@@ -11,10 +11,10 @@ import "./ThreeDimensionalGraph.css";
 
 export default function ThreeDimensionalGraph(
     props: LayoutElementProperties<ThreeDimensionalGraphModel>
-): React.ReactElement {
+): ReactElement {
     const { model } = props;
     const [rootRef, rootDimensions] = useDimensions<HTMLDivElement>();
-    const graphRef: React.ComponentProps<typeof ForceGraph3D>["ref"] = useRef();
+    const graphRef: ComponentProps<typeof ForceGraph3D>["ref"] = useRef();
 
     useWatchAndRerender(model, "graphData");
     // Force the nodes/links to re-render when the selected survey changes. This

--- a/samples/ui-library/src/components/UILibraryComponent/Buttons.tsx
+++ b/samples/ui-library/src/components/UILibraryComponent/Buttons.tsx
@@ -1,9 +1,9 @@
 import { UIContext } from "@vertigis/web/ui";
 import Button from "@vertigis/web/ui/Button";
-import React from "react";
+import { ReactElement, useContext } from "react";
 
-export default function Buttons(): React.ReactElement {
-    const { commands } = React.useContext(UIContext);
+export default function Buttons(): ReactElement {
+    const { commands } = useContext(UIContext);
 
     const handleClick = () =>
         commands.ui.alert.execute({

--- a/samples/ui-library/src/components/UILibraryComponent/FormControls.tsx
+++ b/samples/ui-library/src/components/UILibraryComponent/FormControls.tsx
@@ -9,10 +9,10 @@ import Radio from "@vertigis/web/ui/Radio";
 import RadioGroup from "@vertigis/web/ui/RadioGroup";
 import Select from "@vertigis/web/ui/Select";
 import Typography from "@vertigis/web/ui/Typography";
-import React from "react";
+import { ChangeEvent, ReactElement, useState } from "react";
 
 function CheckboxDemo() {
-    const [state, setState] = React.useState({
+    const [state, setState] = useState({
         gilad: true,
         jason: false,
         antoine: false,
@@ -20,7 +20,7 @@ function CheckboxDemo() {
 
     const { gilad, jason, antoine } = state;
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         setState({ ...state, [event.target.name]: event.target.checked });
     };
 
@@ -69,9 +69,9 @@ function CheckboxDemo() {
 }
 
 function InputDemo() {
-    const [value, setValue] = React.useState("");
+    const [value, setValue] = useState("");
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         setValue((event.target as HTMLInputElement).value);
     };
 
@@ -102,9 +102,9 @@ function InputDemo() {
 }
 
 function RadioDemo() {
-    const [value, setValue] = React.useState("female");
+    const [value, setValue] = useState("female");
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         setValue((event.target as HTMLInputElement).value);
     };
 
@@ -145,9 +145,9 @@ function RadioDemo() {
 }
 
 function SelectDemo() {
-    const [age, setAge] = React.useState("");
+    const [age, setAge] = useState("");
 
-    const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    const handleChange = (event: ChangeEvent<{ value: unknown }>) => {
         setAge(event.target.value as string);
     };
 
@@ -337,7 +337,7 @@ function SelectDemo() {
     );
 }
 
-export default function FormControls(): React.ReactElement {
+export default function FormControls(): ReactElement {
     return (
         <>
             <Typography gutterBottom variant="h2">

--- a/samples/ui-library/src/components/UILibraryComponent/Lists.tsx
+++ b/samples/ui-library/src/components/UILibraryComponent/Lists.tsx
@@ -1,8 +1,8 @@
 import MenuItem from "@vertigis/web/ui/MenuItem";
 import MenuList from "@vertigis/web/ui/MenuList";
-import React from "react";
+import { ReactElement } from "react";
 
-export default function Lists(): React.ReactElement {
+export default function Lists(): ReactElement {
     return (
         <>
             <MenuList aria-label="main mailbox folders">

--- a/samples/ui-library/src/components/UILibraryComponent/Typography.tsx
+++ b/samples/ui-library/src/components/UILibraryComponent/Typography.tsx
@@ -1,7 +1,7 @@
 import Typography from "@vertigis/web/ui/Typography";
-import React from "react";
+import { ReactElement } from "react";
 
-export default function TypographyDemo(): React.ReactElement {
+export default function TypographyDemo(): ReactElement {
     return (
         <>
             <Typography variant="h1" gutterBottom>

--- a/samples/ui-library/src/components/UILibraryComponent/UILibraryComponent.tsx
+++ b/samples/ui-library/src/components/UILibraryComponent/UILibraryComponent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactElement, ReactNode, useState } from "react";
 import {
     LayoutElement,
     LayoutElementProperties,
@@ -21,8 +21,8 @@ function tabA11yProps(index: number) {
 
 export default function UILibraryComponent(
     props: LayoutElementProperties<UILibraryComponentModel>
-): React.ReactElement {
-    const [tabValue, setTabValue] = React.useState(0);
+): ReactElement {
+    const [tabValue, setTabValue] = useState(0);
 
     return (
         <LayoutElement {...props} stretch className="UILibraryComponent">
@@ -56,7 +56,7 @@ export default function UILibraryComponent(
 }
 
 interface TabPanelProps {
-    children?: React.ReactNode;
+    children?: ReactNode;
     index: number;
     value: number;
 }

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -11,7 +11,7 @@ import MenuIcon from "@vertigis/react-ui/icons/Menu";
 import List from "@vertigis/react-ui/List";
 import ListItem from "@vertigis/react-ui/ListItem";
 import ListItemText from "@vertigis/react-ui/ListItemText";
-import React, { useEffect, useState } from "react";
+import { forwardRef, useEffect, useMemo, useState } from "react";
 import { Link as RouterLink, useHistory, useLocation } from "react-router-dom";
 import Sample from "./Sample";
 import SampleViewer from "./SampleViewer";
@@ -62,9 +62,9 @@ async function getSampleData(sampleName: string): Promise<Sample> {
 function ListItemLink(props) {
     const { children, to, ...other } = props;
 
-    const renderLink = React.useMemo(
+    const renderLink = useMemo(
         () =>
-            React.forwardRef<HTMLAnchorElement>((itemProps, ref) => (
+            forwardRef<HTMLAnchorElement>((itemProps, ref) => (
                 <RouterLink to={to} ref={ref} {...itemProps} />
             )),
         [to]
@@ -129,7 +129,7 @@ function App() {
         ""
     );
     const [selectedSample, setCurrentSample] = useState<Sample>();
-    const [mobileOpen, setMobileOpen] = React.useState(false);
+    const [mobileOpen, setMobileOpen] = useState(false);
 
     useEffect(() => {
         // Set default path if we're at the base path

--- a/viewer/src/ReadmeViewer.tsx
+++ b/viewer/src/ReadmeViewer.tsx
@@ -1,6 +1,6 @@
 import { makeStyles } from "@vertigis/react-ui/styles";
 import marked from "marked";
-import React from "react";
+import { useEffect, useState } from "react";
 import Sample from "./Sample";
 
 interface ReadmeViewerProps {
@@ -16,9 +16,9 @@ const useStyles = makeStyles({
 export default function ReadmeViewer({ sample }: ReadmeViewerProps) {
     const classes = useStyles();
 
-    const [readmeHtml, setReadmeHtml] = React.useState<string>();
+    const [readmeHtml, setReadmeHtml] = useState<string>();
 
-    React.useEffect(() => {
+    useEffect(() => {
         let didCancel = false;
 
         (async () => {

--- a/viewer/src/SampleViewer.tsx
+++ b/viewer/src/SampleViewer.tsx
@@ -1,5 +1,4 @@
 import { makeStyles } from "@vertigis/react-ui/styles";
-import React from "react";
 import Sample from "./Sample";
 import WebViewer from "./WebViewer";
 import ReadmeViewer from "./ReadmeViewer";

--- a/viewer/src/WebViewer.tsx
+++ b/viewer/src/WebViewer.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from "@vertigis/react-ui/styles";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Sample from "./Sample";
 
 interface WebViewerProps {

--- a/viewer/src/index.tsx
+++ b/viewer/src/index.tsx
@@ -1,13 +1,13 @@
-import React from "react";
-import ReactDOM from "react-dom";
+import { StrictMode } from "react";
+import { render } from "react-dom";
 import { BrowserRouter as Router } from "react-router-dom";
 import App from "./App";
 
-ReactDOM.render(
-    <React.StrictMode>
+render(
+    <StrictMode>
         <Router>
             <App />
         </Router>
-    </React.StrictMode>,
+    </StrictMode>,
     document.getElementById("root")
 );


### PR DESCRIPTION
This PR takes advantage of the new JSX emit in React 17, which no longer requires "React" to be in scope. All default imports from "react" were replaced by named imports. In reality, the "react" module doesn't have a default export -- this only works due to synthesized default exports. These changes will make it possible to use a native ESM version of react in future versions of the SDK.